### PR TITLE
fix: Use binary fullname on windows.

### DIFF
--- a/test/bsconfig.json
+++ b/test/bsconfig.json
@@ -3,11 +3,11 @@
   "generators": [
     {
       "name": "atd_t",
-      "command": "npx atdgen -t $in"
+      "command": "../../node_modules/\@jchavarri/bs-atdgen-generator/atdgen.exe -t $in"
     },
     {
       "name": "atd_bs",
-      "command": "npx atdgen -bs $in"
+      "command": "../../node_modules/\@jchavarri/bs-atdgen-generator/atdgen.exe -bs $in"
     }
   ],
   "sources": [


### PR DESCRIPTION
Fix #1 
Ninja use [CreateProcess](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa)

And .exe is bot added
> This parameter must include the file name extension; no default extension is assumed.

Also npx atdgen.exe doesn't work so we have to specify the fullname. I have to use ../../ because ninja is executed inside lib/bs